### PR TITLE
add internal and public NuGet workflow actions

### DIFF
--- a/workflow-templates/keyfactor-nuget-internal.properties.json
+++ b/workflow-templates/keyfactor-nuget-internal.properties.json
@@ -1,0 +1,7 @@
+{
+    "name": "Keyfactor Integrations Internal NuGet Package Workflow",
+    "description": "This template will build and package a NuGet package and add it to the internal package repository on GitHub.",
+    "categories": [
+        "C#"
+    ]
+}

--- a/workflow-templates/keyfactor-nuget-internal.yml
+++ b/workflow-templates/keyfactor-nuget-internal.yml
@@ -1,0 +1,138 @@
+name: Keyfactor Nuget Package - Internal Pre Release
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push
+  push:
+    #only run this workflow when pushing to a branch that has the prerelease suffix
+    branches: 
+        - 'release--[12].[0-9]+.[0-9]+-pre*' 
+        - '!release-[12].[0-9]+.[0-9]+' 
+        
+
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Setup Envrionment
+        id: setup_env
+        run: |
+            echo "Setup Envrionment Variables for Workflow"
+            echo "Working Path: ${Env:GITHUB_WORKSPACE}"
+            $slnPath = (Get-ChildItem -Include *.sln -File -Recurse).fullname
+            $relName = "${{ github.ref }}".Split("/")
+            $repoName = "${{ github.repository }}".Split("/")
+            echo "Solution File Path: ${slnPath}"
+            echo "SOLUTION_PATH=${slnPath}" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+            echo "Release Name: $($relName[-1])"
+            echo "RELEASE_NAME=$($relName[-1])" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+            echo "Repo Name: $($repoName[-1])"
+            echo "REPO_NAME=$($repoName[-1])" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+        
+      - uses: actions/setup-dotnet@v1
+        with:
+            dotnet-version: '3.1.x' # SDK Version to use; x will use the latest version of the 3.1 channel      
+            #dotnet-version: 
+        
+      - name: Add Package Source
+        run: |
+          dotnet nuget add source https://nuget.pkg.github.com/Keyfactor/index.json -n github -u ${{ github.actor }} -p ${{ secrets.BUILD_PACKAGE_ACCESS }} --store-password-in-clear-text
+      
+      # Configures msbuild path envrionment
+      - name: setup-msbuild
+        uses: microsoft/setup-msbuild@v1
+      
+      # Restores Packages to Local Machine
+      - name: restore nuget packages
+        run: |
+          nuget restore ${{ env.SOLUTION_PATH  }}
+      
+      # Runs a set of commands using the runners shell
+      - name: Execute MSBuild Commands
+        run: |
+          MSBuild.exe $Env:SOLUTION_PATH -p:RestorePackagesConfig=true -p:Configuration=Release 
+
+      # Create release before packing in NuGet to use auto-incremented tag name
+      - name: Create Release
+        id: create_release
+        #uses: zendesk/action-create-release@v1 - Update when PR is approved
+        uses: keyfactor/action-create-release@786b73035fa09790f9eb11bb86834a6d7af1c256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: Release ${{ env.RELEASE_NAME  }}
+          body: |
+            [Changelog](../CHANGELOG.MD)
+          draft: false
+          prerelease: true
+          prerelease_suffix: pre
+          auto_increment_type: prerelease
+          tag_schema: semantic
+          commitish: ${{ github.sha }}
+
+      # trim the v* prefix to use the tag as version number
+      - name: Trim Tag Version
+        id: trim_version
+        shell: bash
+        # load the version tag into a bash variable
+        env:
+          version_tag: ${{ steps.create_release.outputs.current_tag }}
+        # replace "v" in the version_tag variable with nothing
+        run: |
+          version=${version_tag/v/}
+          echo ::set-output name=VERSION::${version}
+
+      # moves to the project directory, packs the nuget package with the target GitHub Package Repository, then returns to the previous path location
+      - name: Create NuGet Package
+        run: |
+          Push-Location -Path "${{ github.workspace }}\PamUtilities" -StackName "PreviousPath"
+          nuget pack .\PamUtilities.nuspec -properties "nugetRepo=https://github.com/Keyfactor/internal-nuget-packages.git;nugetVersion=${{ steps.trim_version.outputs.VERSION }}"
+          Pop-Location -StackName "PreviousPath"
+
+      - name: Archive Files
+        run: |
+           md ${{ github.workspace }}\zip\Keyfactor
+           Compress-Archive -Path ${{ github.workspace }}\PamUtilities\*.nupkg,${{ github.workspace }}\PamConfig\bin\Release\*,${{ github.workspace }}\PamUtilities\bin\Release\* -DestinationPath ${{ github.workspace }}\zip\Keyfactor\$Env:REPO_NAME.zip -Force
+      
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          # Artifact name
+          name: ${{ env.REPO_NAME}}.zip
+          # A file, directory or wildcard pattern that describes what to upload
+          path: |
+            ${{ github.workspace }}\zip\Keyfactor\${{ env.REPO_NAME}}.zip
+          # The desired behavior if no files are found using the provided path.
+          if-no-files-found: error # optional, default is warn
+      
+      - name: Upload Release Asset (x64)
+        id: upload-release-asset-x64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}\zip\Keyfactor\${{ env.REPO_NAME}}.zip
+          asset_name: ${{ env.REPO_NAME}}.zip
+          asset_content_type: application/zip
+          
+      - name: Expand released archive
+        run: |
+          Expand-Archive -LiteralPath '${{ github.workspace }}\zip\Keyfactor\${{ env.REPO_NAME}}.zip' -DestinationPath '${{ github.workspace }}\released-archive'
+          
+      - name: Upload NuGet package to GitHub Package Repository (gpr)
+        run: |
+          nuget push ${{ github.workspace }}\released-archive\*.nupkg -source github      

--- a/workflow-templates/keyfactor-nuget-release.properties.json
+++ b/workflow-templates/keyfactor-nuget-release.properties.json
@@ -1,0 +1,7 @@
+{
+    "name": "Keyfactor Integrations Public Release NuGet Package Workflow",
+    "description": "This template will build and package a NuGet package and publicly release it to the package repository on GitHub.",
+    "categories": [
+        "C#"
+    ]
+}

--- a/workflow-templates/keyfactor-nuget-release.yml
+++ b/workflow-templates/keyfactor-nuget-release.yml
@@ -1,0 +1,137 @@
+name: Keyfactor Nuget Package - Public Release
+
+# Controls when the action will run. 
+on:
+  # Triggers the workflow on push
+  push:
+    #only run this workflow when pushing to a branch without the prerelease suffix
+    branches: 
+        - 'release-[12].[0-9]+.[0-9]+' 
+        - '!release--[12].[0-9]+.[0-9]+-pre*' 
+        
+
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - name: Setup Envrionment
+        id: setup_env
+        run: |
+            echo "Setup Envrionment Variables for Workflow"
+            echo "Working Path: ${Env:GITHUB_WORKSPACE}"
+            $slnPath = (Get-ChildItem -Include *.sln -File -Recurse).fullname
+            $relName = "${{ github.ref }}".Split("/")
+            $repoName = "${{ github.repository }}".Split("/")
+            echo "Solution File Path: ${slnPath}"
+            echo "SOLUTION_PATH=${slnPath}" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+            echo "Release Name: $($relName[-1])"
+            echo "RELEASE_NAME=$($relName[-1])" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+            echo "Repo Name: $($repoName[-1])"
+            echo "REPO_NAME=$($repoName[-1])" | Out-File $env:GITHUB_ENV -Encoding utf8 -Append
+        
+      - uses: actions/setup-dotnet@v1
+        with:
+            dotnet-version: '3.1.x' # SDK Version to use; x will use the latest version of the 3.1 channel      
+            #dotnet-version: 
+        
+      - name: Add Package Source
+        run: |
+          dotnet nuget add source https://nuget.pkg.github.com/Keyfactor/index.json -n github -u ${{ github.actor }} -p ${{ secrets.BUILD_PACKAGE_ACCESS }} --store-password-in-clear-text
+      
+      # Configures msbuild path envrionment
+      - name: setup-msbuild
+        uses: microsoft/setup-msbuild@v1
+      
+      # Restores Packages to Local Machine
+      - name: restore nuget packages
+        run: |
+          nuget restore ${{ env.SOLUTION_PATH  }}
+      
+      # Runs a set of commands using the runners shell
+      - name: Execute MSBuild Commands
+        run: |
+          MSBuild.exe $Env:SOLUTION_PATH -p:RestorePackagesConfig=true -p:Configuration=Release 
+
+      # Create release before packing in NuGet to use auto-incremented tag name
+      - name: Create Release
+        id: create_release
+        #uses: zendesk/action-create-release@v1 - Update when PR is approved
+        uses: keyfactor/action-create-release@786b73035fa09790f9eb11bb86834a6d7af1c256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          release_name: Release ${{ env.RELEASE_NAME  }}
+          body: |
+            [Changelog](../CHANGELOG.MD)
+          draft: false
+          prerelease: false
+          auto_increment_type: patch
+          tag_schema: semantic
+          commitish: ${{ github.sha }}
+
+      # trim the v* prefix to use the tag as version number
+      - name: Trim Tag Version
+        id: trim_version
+        shell: bash
+        # load the version tag into a bash variable
+        env:
+          version_tag: ${{ steps.create_release.outputs.current_tag }}
+        # replace "v" in the version_tag variable with nothing
+        run: |
+          version=${version_tag/v/}
+          echo ::set-output name=VERSION::${version}
+
+      # moves to the project directory, packs the nuget package with the target GitHub Package Repository, then returns to the previous path location
+      - name: Create NuGet Package
+        run: |
+          Push-Location -Path "${{ github.workspace }}\PamUtilities" -StackName "PreviousPath"
+          nuget pack .\PamUtilities.nuspec -properties "nugetRepo=https://github.com/Keyfactor/public-nuget-packages.git;nugetVersion=${{ steps.trim_version.outputs.VERSION }}"
+          Pop-Location -StackName "PreviousPath"
+
+      - name: Archive Files
+        run: |
+           md ${{ github.workspace }}\zip\Keyfactor
+           Compress-Archive -Path ${{ github.workspace }}\PamUtilities\*.nupkg,${{ github.workspace }}\PamConfig\bin\Release\*,${{ github.workspace }}\PamUtilities\bin\Release\* -DestinationPath ${{ github.workspace }}\zip\Keyfactor\$Env:REPO_NAME.zip -Force
+      
+
+      - name: Upload a Build Artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          # Artifact name
+          name: ${{ env.REPO_NAME}}.zip
+          # A file, directory or wildcard pattern that describes what to upload
+          path: |
+            ${{ github.workspace }}\zip\Keyfactor\${{ env.REPO_NAME}}.zip
+          # The desired behavior if no files are found using the provided path.
+          if-no-files-found: error # optional, default is warn
+      
+      - name: Upload Release Asset (x64)
+        id: upload-release-asset-x64
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}\zip\Keyfactor\${{ env.REPO_NAME}}.zip
+          asset_name: ${{ env.REPO_NAME}}.zip
+          asset_content_type: application/zip
+          
+      - name: Expand released archive
+        run: |
+          Expand-Archive -LiteralPath '${{ github.workspace }}\zip\Keyfactor\${{ env.REPO_NAME}}.zip' -DestinationPath '${{ github.workspace }}\released-archive'
+          
+      - name: Upload NuGet package to GitHub Package Repository (gpr)
+        run: |
+          nuget push ${{ github.workspace }}\released-archive\*.nupkg -source github      


### PR DESCRIPTION
These actions when added to a GitHub repo will allow for automated building, packaging and pushing to the internal or public repository of NuGet packages.

To use the workflows, the template would need to be edited to match the build output structure to target the `.nuspec` file correctly. Additionally, it is currently assumed that the package to be created is defined in a `.nuspec` file, and has `$nugetVersion$` and `$nugetRepo$` placeholders for dynamically setting the package version and repository push target.

I will create an issue for enhancement to support `.csproj` NuGet package definitions.