### PR TITLE
run releases on PR, simplify branch versioning

### DIFF
--- a/workflow-templates/keyfactor-extension-prerelease.yml
+++ b/workflow-templates/keyfactor-extension-prerelease.yml
@@ -8,11 +8,9 @@ on:
   push:
     #only run this workflow when pushing to a branch that has the prerelease suffix
     branches: 
-        - 'release--[12].[0-9]+.[0-9]+-pre*' 
-        - '!release-[12].[0-9]+.[0-9]+' 
+        - 'release-[0-9]+.[0-9]+-pre' 
+        - '!release-[0-9]+.[0-9]+' 
         
-
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/workflow-templates/keyfactor-extension-release.yml
+++ b/workflow-templates/keyfactor-extension-release.yml
@@ -4,12 +4,13 @@ name: Keyfactor Extension - Release
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push
-  push:
-    #only run this workflow when pushing to a branch that contains a release number. ignore -pre
+  # Triggers the workflow on pull requests closing
+  pull_request:
+    # only run this workflow when closing a PR to a branch that contains a release number. ignore -pre
     branches: 
-        - 'release-[12].[0-9]+.[0-9]+' 
-        - '!release--[12].[0-9]+.[0-9]+-pre*' 
+        - 'release-[0-9]+.[0-9]+' 
+        - '!release-[0-9]+.[0-9]+-pre' 
+    types: [closed]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -18,6 +19,9 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+      # run if pull request is completed and merged, or if manually dispatched
+    if:  github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
+
     # The type of runner that the job will run on
     runs-on: windows-latest
 

--- a/workflow-templates/keyfactor-nuget-internal.yml
+++ b/workflow-templates/keyfactor-nuget-internal.yml
@@ -6,11 +6,9 @@ on:
   push:
     #only run this workflow when pushing to a branch that has the prerelease suffix
     branches: 
-        - 'release--[12].[0-9]+.[0-9]+-pre*' 
-        - '!release-[12].[0-9]+.[0-9]+' 
+        - 'release-[0-9]+.[0-9]+-pre' 
+        - '!release-[0-9]+.[0-9]+' 
         
-
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/workflow-templates/keyfactor-nuget-release.yml
+++ b/workflow-templates/keyfactor-nuget-release.yml
@@ -2,15 +2,14 @@ name: Keyfactor Nuget Package - Public Release
 
 # Controls when the action will run. 
 on:
-  # Triggers the workflow on push
-  push:
-    #only run this workflow when pushing to a branch without the prerelease suffix
+  # Triggers the workflow on pull requests closing
+  pull_request:
+    # only run this workflow when closing a PR to a branch that contains a release number. ignore -pre
     branches: 
-        - 'release-[12].[0-9]+.[0-9]+' 
-        - '!release--[12].[0-9]+.[0-9]+-pre*' 
+        - 'release-[0-9]+.[0-9]+' 
+        - '!release-[0-9]+.[0-9]+-pre' 
+    types: [closed]
         
-
-
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
@@ -18,6 +17,9 @@ on:
 jobs:
   # This workflow contains a single job called "build"
   build:
+    # run if pull request is completed and merged, or if manually dispatched
+    if:  github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.action == 'closed' && github.event.pull_request.merged == true)
+
     # The type of runner that the job will run on
     runs-on: windows-latest
 


### PR DESCRIPTION
This PR stops the release actions from automatically running when the branch is initially created, as well as when a code push happens directly to the release branch. A pull request should be used to make changes to the release branch which will kick off the build when it is successfully merged.

Builds can still be run manually.

Also updated is the expected branch versioning - the patch number is auto-incremented by the GitHub Action and so it is no longer expected to be in the branch name.

Fixes #4 