### PR TITLE
create PRIVATE_REPO_ACCESS secret with access to private repositories.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+﻿################################################################################
+# This .gitignore file was automatically created by Microsoft(R) Visual Studio.
+################################################################################
+
+/.vs/VSWorkspaceState.json
+/.vs/slnx.sqlite
+/.vs/.github/v17/.suo
+/.vs/.github/v17
+/.vs

--- a/workflow-templates/keyfactor-starter-workflow.yml
+++ b/workflow-templates/keyfactor-starter-workflow.yml
@@ -7,11 +7,13 @@ jobs:
 
   call-dotnet-build-and-release-workflow:
     needs: [call-create-github-release-workflow]
-    uses: Keyfactor/actions/.github/workflows/dotnet-build-and-release.yml@main
+    uses: Keyfactor/actions/.github/workflows/dotnet-build-and-release.yml@secret-testing
     with:
       release_version: ${{ needs.call-create-github-release-workflow.outputs.release_version }}
       release_url: ${{ needs.call-create-github-release-workflow.outputs.release_url }}
       release_dir: EXAMPLE_SOLUTION/bin/Release/BUILD_TARGET # TODO: set build output directory to upload as a release, relative to checkout workspace
+    secrets: 
+      token: ${{ secrets.PRIVATE_REPO_ACCESS  }}
 
   call-generate-readme-workflow:
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Use secret-testing branch for dotnet-build-and-release workflow. This should be moved to @main branch when changes have been finalized