### PR TITLE
Suggestions from Community team

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -8,7 +8,6 @@
 ---
 For help to easily browse through our Git repositories, see below. If you want to learn more about Keyfactor, visit [keyfactor.com](https://www.keyfactor.com/). 
 
----
 ### Open-source editions of EJBCA and SignServer 
 Our PKI and signing solutions are available as free and open-source software. 
 
@@ -17,8 +16,6 @@ Our PKI and signing solutions are available as free and open-source software.
 - Open-source signing software - [See **SignServer Community** and related tools](https://github.com/search?q=org%3AKeyfactor+signserver&type=repositories&s=stars).
 
 If you are looking for Bouncy Castle Cryptographic APIs, visit [Bouncy Castle on GitHub](https://github.com/bcgit). 
-
----
 
 ### Extensions and Plugins for Command and Signum
 <details>

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,5 +1,181 @@
-# [Keyfactor](https://keyfactor.com)
+# Keyfactor
+<!-- img src="logo-temp.png" height=120/>-->
+<!-- <img src="https://github.com/Keyfactor/.github-private/blob/main/profile/wearekeyfactor_cover.jpg"/>
+-->
+<!-- <img src="wearekeyfactor_cover.jpg"/>-->
 
-Delivering identity-first security for every device, workload, and thing. Because when you establish digital trust, great things happen.
+#### _Delivering identity-first security for every device, workload, and thing. Because when you establish digital trust, great things happen._
+Learn more on [keyfactor.com](https://www.keyfactor.com/). For help to easily browse through our Git repositories, see below. 
 
+---
+### Open-source editions of EJBCA and SignServer 
+Our PKI and signing solutions are available as free and open-source software. 
+
+- Open-source PKI software - [See **EJBCA Community** and related tools](https://github.com/search?q=org%3AKeyfactor%20ejbca&type=repositories&s=stars).
+
+- Open-source signing software - [See **SignServer Community** and related tools](https://github.com/search?q=org%3AKeyfactor+signserver&type=repositories&s=stars).
+
+If you are looking for Bouncy Castle Cryptographic APIs, please visit [Bouncy Castle on GitHub](https://github.com/bcgit). 
+
+---
+
+### Extensions and Plugins for Command and Signum
+<details>
+	<summary>Orchestrators</summary>
+
+# [All Orchestrators](https://github.com/orgs/Keyfactor/repositories?q=keyfactor-universal-orchestrator&type=public&language=&sort=stargazers)
+
+<table>
+  <tr>
+    <td colspan=3>
+      Some of the most starred Universal Orchestrator extensions
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="https://github.com/Keyfactor/iis-orchestrator">
+        <img src="https://avatars.githubusercontent.com/u/6154722?s=200&v=4" alt="IIS/WinCert Orchestrator" title="IIS/WinCert Orchestrator" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/azurekeyvault-orchestrator">
+        <img src="https://avatars.githubusercontent.com/u/6844498?s=200&v=4" alt="Azure Key Vault Universal Orchestrator" title="Azure Key Vault Universal Orchestrator" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/aws-orchestrator">
+        <img src="https://avatars.githubusercontent.com/u/2232217?s=200&v=4" alt="AWS Certificate Manager" title="AWS Certificate Manager" width="75">
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="https://github.com/Keyfactor/paloalto-firewall-orchestrator">
+        <img src="https://avatars.githubusercontent.com/u/4855743?s=200&v=4" alt="PaloAlto VM Firewall Orchestrator" title="PaloAlto VM Firewall Orchestrator" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/akamai-cps-orchestrator">
+        <img src="https://avatars.githubusercontent.com/u/5497190?s=200&v=4" alt="Akamai Certificate Provisioning System Orchestrator" title="Akamai Certificate Provisioning System Orchestrator" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/f5-rest-orchestrator">
+        <img src="https://avatars.githubusercontent.com/u/8935905?s=200&v=4" alt="F5Networks Rest Orchestrator" title="F5Networks Rest Orchestrator" width="75">
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td colspan=3>
+      <a href="https://github.com/orgs/Keyfactor/repositories?q=keyfactor-universal-orchestrator&type=public&language=&sort=stargazers">Click here for our full list of Universal Orchestrators</a>
+    </td>
+  </tr>
+</table>
+
+</details> 
+
+<details>
+	<summary>CA Gateways</summary>
+
+# [All CA Gateways](https://github.com/orgs/Keyfactor/repositories?q=keyfactor-cagateway&type=public&language=&sort=stargazers)
+
+<table>
+  <tr>
+    <td colspan=3>
+      Some of the most starred CA Gateway extensions
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="https://github.com/Keyfactor/godaddy-cagateway">
+        <img src="https://avatars.githubusercontent.com/u/1406546?s=200&v=4" alt="GoDaddy Gateway" title="GoDaddy Gateway" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/digicert-certcentral-cagateway">
+        <img src="https://avatars.githubusercontent.com/u/11575539?s=200&v=4" alt="DigiCert CertCentral Gateway" title="DigiCert CertCentral Gateway" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/entrust-cagateway">
+        <img src="https://www.entrust.com/-/media/entrust/corporate/logo-entrust.svg" alt="Entrust Gateway" title="Entrust Gateway" width="75">
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="https://github.com/Keyfactor/sectigo-certmanager-cagateway">
+        <img src="https://avatars.githubusercontent.com/u/13418598?s=200&v=4" alt="Sectigo Gateway" title="Sectigo Gateway" width="75">
+      </a>
+    </td>
+    <td></td>
+    <td></td>
+  </tr>
+  <tr>
+    <td colspan=3>
+      <a href="https://github.com/orgs/Keyfactor/repositories?q=keyfactor-cagateway&type=public&language=&sort=stargazers">Click here for our full list of CA Gateway extensions</a>
+    </td>
+  </tr>
+</table>
+
+</details> 
+
+<details>
+	<summary>PAM Providers</summary>
+
+# [All PAM Providers](https://github.com/orgs/Keyfactor/repositories?q=keyfactor-pam&type=public&language=&sort=stargazers)
+
+<table>
+  <tr>
+    <td colspan=3>
+      Some of the most starred PAM Provider  plugins
+    </td>
+  </tr>
+    <td>
+      <a href="https://github.com/Keyfactor/cyberark-credentialprovider-pam">
+        <img src="https://avatars.githubusercontent.com/u/30869256?s=200&v=4" alt="CyberArk Credential Provider" title="CyberArk Credential Provider" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/delinea-secretserver-pam">
+        <img src="https://media.licdn.com/dms/image/C560BAQGhHJZqbWPI7Q/company-logo_200_200/0/1643468128461/delinea_logo?e=2147483647&v=beta&t=i-k1OBNM26VggBZk_mp3JpZLFy62C2eDXhYoS6EUN9s" alt="Delinea SecretServer" title="Delinea SecretServer" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/beyondtrust-beyondinsight-pam">
+        <img src="https://avatars.githubusercontent.com/u/21182961?s=200&v=4" alt="BeyondTrust" title="BeyondTrust" width="75">
+      </a>
+    </td>
+  </tr>
+  <tr>
+    <td>
+      <a href="https://github.com/Keyfactor/hashicorp-vault-pam">
+        <img src="https://avatars.githubusercontent.com/u/761456?s=200&v=4" alt="HashiCorp Vault" title="HashiCorp Vault" width="75">
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Keyfactor/gcp-secretmanager-pam">
+        <img src="https://avatars.githubusercontent.com/u/2810941?s=200&v=4" alt="Google Secret Manager" title="Google Secret Manager" width="75">
+      </a>
+    </td>
+    <td></td>
+  </tr>
+  <tr>
+    <td colspan=3>
+      <a href="https://github.com/orgs/Keyfactor/repositories?q=keyfactor-pam&type=public&language=&sort=stargazers">Click here for our full list of PAM Provider plugins</a>
+    </td>
+  </tr>
+</table>
+
+</details> 
+
+
+### Integrations Catalog
 For a complete list of our orchestrator, PAM provider, and ca-gateway integrations for Command, [visit our catalog](https://keyfactor.github.io/integrations-catalog/).
+
+
+---
+## Trademarks
+This project may contain trademarks or logos for projects, products, or services. Any use of third-party trademarks or logos is subject to those third-party's policies.
+
+EJBCA® is a registered trademark owned by PrimeKey Solutions AB, a wholly-owned subsidiary of Keyfactor Inc. 

--- a/profile/README.md
+++ b/profile/README.md
@@ -5,7 +5,8 @@
 <!-- <img src="wearekeyfactor_cover.jpg"/>-->
 
 #### _Delivering identity-first security for every device, workload, and thing. Because when you establish digital trust, great things happen._
-Learn more on [keyfactor.com](https://www.keyfactor.com/). For help to easily browse through our Git repositories, see below. 
+---
+For help to easily browse through our Git repositories, see below. If you want to learn more about Keyfactor, visit [keyfactor.com](https://www.keyfactor.com/). 
 
 ---
 ### Open-source editions of EJBCA and SignServer 
@@ -15,7 +16,7 @@ Our PKI and signing solutions are available as free and open-source software.
 
 - Open-source signing software - [See **SignServer Community** and related tools](https://github.com/search?q=org%3AKeyfactor+signserver&type=repositories&s=stars).
 
-If you are looking for Bouncy Castle Cryptographic APIs, please visit [Bouncy Castle on GitHub](https://github.com/bcgit). 
+If you are looking for Bouncy Castle Cryptographic APIs, visit [Bouncy Castle on GitHub](https://github.com/bcgit). 
 
 ---
 


### PR DESCRIPTION
Suggest to remove the header image and decreasing the size of the marketing message  -> Easier for our techy GitHub users to find what they are looking for without scrolling. They can go to our homepage to learn more. 

Suggest to move Open-source section up. -> These are by far our most popular repos and an important part of promoting our Community versions to new users (which in turn can become paying users). 

Minor: rewritten parts of intro and Open-source sections.